### PR TITLE
dump all data as a big hash

### DIFF
--- a/lib/tasks/db_fixtures_dump.rake
+++ b/lib/tasks/db_fixtures_dump.rake
@@ -30,17 +30,18 @@ namespace :db do
 
         # use test/fixtures if you do test:unit
         model_file = Rails.root + ('spec/fixtures/' + m.underscore.pluralize + '.yml')
-        File.open(model_file, 'w') do |f|
-          entries.each do |a|
-            attrs = a.attributes
-            attrs.delete_if{|k,v| v.nil?}
+        output = {}
+        entries.each do |a|
+          attrs = a.attributes
+          attrs.delete_if{|k,v| v.nil?}
 
-            output = {m + '_' + increment.to_s => attrs}
-            f << output.to_yaml.gsub(/^---\s?\n/,'') + "\n"
+          output["#{m}_#{increment}"] = attrs
 
-            increment += 1
-          end
+          increment += 1
         end
+        file = File.open(model_file, 'w')
+        file << output.to_yaml
+        file.close #better than relying on gc
       end
     end
   end


### PR DESCRIPTION
This is the fix i did for my Issue 3, I think it fixes the latest issue 7 too.

I had this lying around for months, never saw your reply to the issue, sorry.

The change looks bigger than it is because the file open collapses the code. It just avoids this hand-coding of yaml that was happening between the objects which seems to have caused problems.
