### PR TITLE
Add ability to exclude models

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,16 @@ Just like for the db:fixtures:load , you may specify FIXTURES_PATH to be used as
 
     $ FIXTURES_PATH=db/backup rake db:fixtures:dump
 
+### Excluding models
+
+You can exclude models by specifying a list as EXCLUDE_MODELS.
+
+	$ EXCLUDE_MODELS="MyLegacyModel AnotherOne" rake db:fixtures:dump
+
+Or in combination with FIXTURES_PATH,
+
+	$ EXCLUDE_MODELS="MyLegacyModel AnotherOne" FIXTURES_PATH=test/fixtures rake db:fixtures:dump
+
 ## Contributing
 
 1. Fork it

--- a/lib/tasks/db_fixtures_dump.rake
+++ b/lib/tasks/db_fixtures_dump.rake
@@ -31,7 +31,7 @@ namespace :db do
         increment = 1
 
         # use test/fixtures if you do test:unit
-        model_file = Rails.root + (dump_dir + m.underscore.pluralize + '.yml')
+        model_file = File.join(Rails.root, dump_dir, m.underscore.pluralize + '.yml')
         output = {}
         entries.each do |a|
           attrs = a.attributes

--- a/lib/tasks/db_fixtures_dump.rake
+++ b/lib/tasks/db_fixtures_dump.rake
@@ -18,10 +18,15 @@ namespace :db do
       end
       # specify FIXTURES_PATH to test/fixtures if you do test:unit
       dump_dir = ENV['FIXTURES_PATH'] || "spec/fixtures"
+      excludes = []
+      excludes = ENV['EXCLUDE_MODELS'].split(' ') if ENV['EXCLUDE_MODELS']
       puts "Found models: " + models.join(', ')
+      puts "Excluding: " + excludes.join(', ')
       puts "Dumping to: " + dump_dir
 
       models.each do |m|
+        next if excludes.include?(m)
+
         model = m.constantize
         next unless model.ancestors.include?(ActiveRecord::Base)
 


### PR DESCRIPTION
Hi,

This simple patch adds the ability to exclude specific models by way of an environment variable, e.g. 

    EXCLUDE_MODELS="MyLegacyModel AnotherOne" rake db:fixtures:dump

Also contains a small patch to deal with if the user sets `FIXTURES_PATH=test/fixtures` then they'll get `text/fixturesrecord.yml` files rather than the expected `text/fixtures/records.yml` file.