### PR TITLE
Option to dump only explicitly included models

### DIFF
--- a/lib/tasks/db_fixtures_dump.rake
+++ b/lib/tasks/db_fixtures_dump.rake
@@ -20,6 +20,12 @@ namespace :db do
       dump_dir = ENV['FIXTURES_PATH'] || "spec/fixtures/"
       excludes = []
       excludes = ENV['EXCLUDE_MODELS'].split(' ') if ENV['EXCLUDE_MODELS']
+      
+      if ENV['INCLUDE_MODELS']
+        included_models = ENV['INCLUDE_MODELS'].split(' ') 
+        models = models & included_models
+      end
+      
       puts "Found models: " + models.join(', ')
       puts "Excluding: " + excludes.join(', ')
       puts "Dumping to: " + dump_dir


### PR DESCRIPTION
Usage:

```
INCLUDE_MODELS="Post Site" rake db:fixtures:dump
```